### PR TITLE
fixes for fund, defund and fee check in accept transfer call

### DIFF
--- a/src/ERC7399Lender.sol
+++ b/src/ERC7399Lender.sol
@@ -40,8 +40,8 @@ contract ERC7399Lender is IERC7399 {
 
     /// @dev Add funds to this contract. The assets must have been transferred previous to this call.
     /// @param amount The amount of asset to add.
-    function fund(uint256 amount) external {
-        _acceptTransfer(amount);
+    function sync(uint256 amount) external {
+        reserves = asset.balanceOf(address(this));
         emit Fund(amount);
     }
 
@@ -50,18 +50,20 @@ contract ERC7399Lender is IERC7399 {
         if (msg.sender != owner) {
             revert OnlyOwner(msg.sender, owner);
         }
+
+        reserves = 0;
         uint256 amount = asset.balanceOf(address(this));
         asset.transfer(owner, amount);
         emit Defund(amount);
     }
 
     /// @inheritdoc IERC7399
-    function maxFlashLoan(address asset_) isSupported(asset_) external view returns (uint256) {
+    function maxFlashLoan(address asset_) external view isSupported(asset_) returns (uint256) {
         return _maxFlashLoan();
     }
 
     /// @inheritdoc IERC7399
-    function flashFee(address asset_, uint256 amount) isSupported(asset_) external view returns (uint256) {
+    function flashFee(address asset_, uint256 amount) external view isSupported(asset_) returns (uint256) {
         return amount <= reserves ? _flashFee(amount) : type(uint256).max;
     }
 
@@ -73,13 +75,13 @@ contract ERC7399Lender is IERC7399 {
         bytes calldata data,
         function(address, address, address, uint256, uint256, bytes memory) external returns (bytes memory) callback
     )
-        isSupported(asset_) // Revert on unsupported assets
         external
+        isSupported(asset_) // Revert on unsupported assets
         returns (bytes memory)
     {
         // Calculate the fee to charge for the loan
         uint256 fee_ = _flashFee(amount);
-        
+
         // Transfer the loan to the loan receiver
         _serveLoan(loanReceiver, amount);
 
@@ -87,7 +89,7 @@ contract ERC7399Lender is IERC7399 {
         bytes memory result = callback(msg.sender, _repayTo(), asset_, amount, fee_, data);
 
         // Verify and accept the repayment
-        _acceptTransfer(amount + fee);
+        _acceptTransfer(amount + fee_);
 
         emit Flash(IERC20(asset_), amount, fee_);
 
@@ -125,7 +127,7 @@ contract ERC7399Lender is IERC7399 {
     function _acceptTransfer(uint256 amount) internal {
         uint256 expectedReserves = reserves + amount;
         uint256 currentReserves = asset.balanceOf(address(this));
-        
+
         // We do not accept donations for security reasons.
         // Excess assets can be removed by using `flash`.
         reserves = expectedReserves;

--- a/src/ERC7399Lender.sol
+++ b/src/ERC7399Lender.sol
@@ -12,7 +12,7 @@ import { UnsupportedToken, InsufficientBalance, OnlyOwner } from "./lib/Errors.s
  */
 contract ERC7399Lender is IERC7399 {
     event Flash(IERC20 indexed asset, uint256 amount, uint256 fee);
-    event Fund(uint256 amount);
+    event Sync();
     event Defund(uint256 amount);
 
     address public immutable owner;
@@ -39,10 +39,9 @@ contract ERC7399Lender is IERC7399 {
     }
 
     /// @dev Add funds to this contract. The assets must have been transferred previous to this call.
-    /// @param amount The amount of asset to add.
-    function sync(uint256 amount) external {
+    function sync() external {
         reserves = asset.balanceOf(address(this));
-        emit Fund(amount);
+        emit Sync();
     }
 
     /// @dev Remove all funds from this contract

--- a/src/ERC7399MultiLender.sol
+++ b/src/ERC7399MultiLender.sol
@@ -17,7 +17,7 @@ contract ERC7399MultiLender is IERC7399 {
 
     address public immutable owner;
     uint256 public immutable fee; //  1 == 0.01 %.
-    mapping (IERC20 asset => uint256 balance) public reserves;
+    mapping(IERC20 asset => uint256 balance) public reserves;
 
     /**
      * @param fee_ Fee charged on flash loans
@@ -119,7 +119,7 @@ contract ERC7399MultiLender is IERC7399 {
     function _acceptTransfer(IERC20 asset, uint256 amount) internal {
         uint256 expectedReserves = reserves[asset] + amount;
         uint256 currentReserves = asset.balanceOf(address(this));
-        
+
         // We do not accept donations for security reasons.
         // Excess assets can be removed by using `flash`.
         reserves[asset] = expectedReserves;

--- a/src/interfaces/IERC20.sol
+++ b/src/interfaces/IERC20.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.7.0 || ^0.8.4;
+pragma solidity >=0.8.19;
 
 /**
  * @dev Interface of the ERC20 standard as defined in the EIP.
  */
 interface IERC20 {
-
     /**
      * @dev Returns the name of the token.
      */

--- a/src/lib/ERC20.sol
+++ b/src/lib/ERC20.sol
@@ -17,24 +17,25 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity  ^0.8.4;
+pragma solidity >=0.8.19;
+
 import { IERC20 } from "../interfaces/IERC20.sol";
 
 contract ERC20 is IERC20 {
-    uint256                                           internal  _totalSupply;
-    mapping (address => uint256)                      internal  _balanceOf;
-    mapping (address => mapping (address => uint256)) internal  _allowance;
-    string                                            public    symbol;
-    uint8                                             public    decimals = 18; // standard token precision. override to customize
-    string                                            public    name = "";     // Optional token name
+    uint256 internal _totalSupply;
+    mapping(address => uint256) internal _balanceOf;
+    mapping(address => mapping(address => uint256)) internal _allowance;
+    string public symbol;
+    uint8 public decimals = 18; // standard token precision. override to customize
+    string public name = ""; // Optional token name
 
     constructor(string memory name_, string memory symbol_) {
         name = name_;
         symbol = symbol_;
     }
 
-    event Mint(address indexed dst, uint wad);
-    event Burn(address indexed src, uint wad);
+    event Mint(address indexed dst, uint256 wad);
+    event Burn(address indexed src, uint256 wad);
 
     function totalSupply() public view returns (uint256) {
         return _totalSupply;
@@ -48,17 +49,17 @@ contract ERC20 is IERC20 {
         return _allowance[owner][spender];
     }
 
-    function approve(address spender, uint wad) public returns (bool) {
+    function approve(address spender, uint256 wad) public returns (bool) {
         return _approve(msg.sender, spender, wad);
     }
 
-    function transfer(address dst, uint wad) external returns (bool) {
+    function transfer(address dst, uint256 wad) external returns (bool) {
         return transferFrom(msg.sender, dst, wad);
     }
 
-    function transferFrom(address src, address dst, uint wad) public returns (bool) {
+    function transferFrom(address src, address dst, uint256 wad) public returns (bool) {
         uint256 allowed = _allowance[src][msg.sender];
-        if (src != msg.sender && allowed != type(uint).max) {
+        if (src != msg.sender && allowed != type(uint256).max) {
             require(allowed >= wad, "ERC20: insufficient-approval");
             _approve(src, msg.sender, allowed - wad);
         }
@@ -72,19 +73,19 @@ contract ERC20 is IERC20 {
         return true;
     }
 
-    function _approve(address owner, address spender, uint wad) internal returns (bool) {
+    function _approve(address owner, address spender, uint256 wad) internal returns (bool) {
         _allowance[owner][spender] = wad;
         emit Approval(owner, spender, wad);
         return true;
     }
 
-    function _mint(address dst, uint wad) internal {
+    function _mint(address dst, uint256 wad) internal {
         _balanceOf[dst] = _balanceOf[dst] + wad;
         _totalSupply = _totalSupply + wad;
         emit Mint(dst, wad);
     }
 
-    function _burn(address src, uint wad) internal {
+    function _burn(address src, uint256 wad) internal {
         require(_balanceOf[src] >= wad, "ERC20: insufficient-balance");
         _balanceOf[src] = _balanceOf[src] - wad;
         _totalSupply = _totalSupply - wad;

--- a/src/lib/Errors.sol
+++ b/src/lib/Errors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity >=0.8.19;
 
 error OnlyOwner(address caller, address owner);
 error UnsupportedToken(address token);

--- a/test/ERC7399Lender.t.sol
+++ b/test/ERC7399Lender.t.sol
@@ -29,7 +29,7 @@ contract ERC7399LenderTest is PRBTest, StdCheats {
         borrower = new FlashBorrower(lender);
 
         IERC20(asset).transfer(address(lender), reserves); // Keeping 1e18 for the flash fee.
-        lender.sync(reserves);
+        lender.sync();
     }
 
     /// @dev Simple flash loan test.

--- a/test/ERC7399Lender.t.sol
+++ b/test/ERC7399Lender.t.sol
@@ -12,7 +12,7 @@ import { IERC20 } from "../src/interfaces/IERC20.sol";
 
 /// @dev If this is your first time with Forge, read this tutorial in the Foundry Book:
 /// https://book.getfoundry.sh/forge/writing-tests
-contract FlashLenderTest is PRBTest, StdCheats {
+contract ERC7399LenderTest is PRBTest, StdCheats {
     ERC7399Lender internal lender;
     FlashBorrower internal borrower;
     address internal asset;
@@ -29,7 +29,7 @@ contract FlashLenderTest is PRBTest, StdCheats {
         borrower = new FlashBorrower(lender);
 
         IERC20(asset).transfer(address(lender), reserves); // Keeping 1e18 for the flash fee.
-        lender.fund(reserves);
+        lender.sync(reserves);
     }
 
     /// @dev Simple flash loan test.
@@ -44,7 +44,8 @@ contract FlashLenderTest is PRBTest, StdCheats {
         assertEq(borrower.flashInitiator(), address(borrower));
         assertEq(address(borrower.flashAsset()), address(asset));
         assertEq(borrower.flashAmount(), loan);
-        assertEq(borrower.flashBalance(), loan + flashFee); // The amount we transferred to pay for fees, plus the amount we
+        assertEq(borrower.flashBalance(), loan + flashFee); // The amount we transferred to pay for fees, plus the
+            // amount we
             // borrowed
         assertEq(borrower.flashFee(), flashFee);
         assertEq(IERC20(asset).balanceOf(address(lender)), lenderBalance + flashFee);

--- a/test/ERC7399MultiLender.t.sol
+++ b/test/ERC7399MultiLender.t.sol
@@ -47,7 +47,8 @@ contract ERC7399MultiLenderTest is PRBTest, StdCheats {
         assertEq(borrower.flashInitiator(), address(borrower));
         assertEq(address(borrower.flashAsset()), address(asset));
         assertEq(borrower.flashAmount(), loan);
-        assertEq(borrower.flashBalance(), loan + flashFee); // The amount we transferred to pay for fees, plus the amount we
+        assertEq(borrower.flashBalance(), loan + flashFee); // The amount we transferred to pay for fees, plus the
+            // amount we
             // borrowed
         assertEq(borrower.flashFee(), flashFee);
         assertEq(IERC20(asset).balanceOf(address(lender)), lenderBalance + flashFee);

--- a/test/stub/ERC20FlashMintMock.sol
+++ b/test/stub/ERC20FlashMintMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity >=0.8.19;
 
 import { FlashMinter } from "src/FlashMinter.sol";
 

--- a/test/stub/ERC20Mock.sol
+++ b/test/stub/ERC20Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity >=0.8.19;
 
 import { ERC20 } from "src/lib/ERC20.sol";
 

--- a/test/stub/FlashBorrower.sol
+++ b/test/stub/FlashBorrower.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity >=0.8.19;
 
 import "erc7399/IERC7399.sol";
 


### PR DESCRIPTION
- Changes `fund` function name to `sync`
- updates reserve in `fund(sync)` and in `defund`
- use `fee_` and not `fee` when calling `acceptTransfer`
- change ERC7399 Lender Test name to `ERC7399LenderTest`